### PR TITLE
Fix issue with AES 256 breaking when running in Electron

### DIFF
--- a/src/algorithms/aes256.js
+++ b/src/algorithms/aes256.js
@@ -8,7 +8,13 @@ const SymmetricAlgo = require('../lib/SymmetricAlgo')
 
 class AES256 extends SymmetricAlgo {
   constructor() {
-    super('aes256', 16)
+    let algoName = 'aes256';
+    const versions = process.versions;
+    if (versions.hasOwnProperty('electron') ||
+      (versions.hasOwnProperty('v8') && versions.v8.toLowerCase().indexOf('electron') > -1)) {
+      algoName = 'aes-256-cbc';
+    }
+    super(algoName, 16);
   }
 }
 


### PR DESCRIPTION
The name used for the AES 256 algorithm will break Cryptex when used in Electron 73. It seems like the fix to this issue is by changing the algorithm name to `aes-256-cbc` for the crypto package to work. Otherwise, an "Unknown Cipher" error message will be thrown.

This PR attempts to detect whether the environment is Electron or not. If it is, we will use `aes-256-cbc` as the algorithm name. Otherwise, we will use `aes256` in a regular Node environment.