### PR TITLE
Use parserConfiguration api and remove package.json configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "url": "https://github.com/TomFrost/Cryptex/issues"
   },
   "homepage": "https://github.com/TomFrost/Cryptex#readme",
-  "yargs": {
-    "parse-numbers": false
-  },
   "eslintIgnore": [
     "node_modules",
     "coverage"

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ const UserError = require('./lib/UserError')
 const yargs = require('yargs')
 
 const argv = yargs
+  .parserConfiguration({ 'parse-numbers': false })
   .usage('Usage: $0 [options] <command>')
   .command('encrypt <plaintext>', 'Encrypt the given plaintext string')
   .command('decrypt <base64>', 'Decrypt the given base64 string')


### PR DESCRIPTION
package.json-based parserConfiguration has been deprecated since v13.0.0 and was removed in v15.0.0

Closes #17 